### PR TITLE
Fix encoding

### DIFF
--- a/AGSExtract/AGSGame.cs
+++ b/AGSExtract/AGSGame.cs
@@ -88,7 +88,7 @@ namespace AGSExtractWPF
 
         private static string decryptText(byte[] enc)
         {
-            byte[] pass = Encoding.Default.GetBytes(ENCPASS);
+            byte[] pass = Encoding.GetEncoding(1252).GetBytes(ENCPASS);
             uint adx = 0;
             byte[] dec = new byte[enc.Length];
 


### PR DESCRIPTION
`Encoding.Default` changes based on the operating system's settings, you want to use Windows-1252.